### PR TITLE
add litespeed support, fix json

### DIFF
--- a/SPECS/php55u.spec
+++ b/SPECS/php55u.spec
@@ -77,7 +77,7 @@
 Summary: PHP scripting language for creating dynamic web sites
 Name: %{name} 
 Version: 5.5.1
-Release: 2.ius%{?dist}
+Release: 3.ius%{?dist}
 # All files licensed under PHP version 3.01, except
 # Zend is licensed under Zend
 # TSRM is licensed under BSD
@@ -1140,7 +1140,7 @@ without_shared="--without-gd \
       --disable-opcache \
       --disable-xmlreader --disable-xmlwriter \
       --without-sqlite3 --disable-phar --disable-fileinfo \
-      --without-pspell --disable-wddx \
+      --without-pspell --disable-wddx --disable-json \
       --without-curl --disable-posix --disable-xml \
       --disable-simplexml --disable-exif --without-gettext \
       --without-iconv --disable-ftp --without-bz2 --disable-ctype \
@@ -1723,6 +1723,9 @@ exit 0
 
 
 %changelog
+* Wed Jul 31 2013 Mark McKinstry <mmckinst@nexcess.net> - 5.5.1-3.ius
+- add json to the list of things not to build when using without_shared
+
 * Wed Jul 31 2013 Mark McKinstry <mmckinst@nexcess.net> - 5.5.1-2.ius
 - add litespeed support
 


### PR DESCRIPTION
3f9878d9190556d268c379ec762511d6d8479777 adds litespeed support

e269ba3a35701ec2c6506fd385ae5e5dc66d7ed4 adds json to the without_shared variable otherwise you get the warning described below

```
# you get a warning about json already being loaded unless its added to the
# without_shared variable that is used when building php55u-litespeed and
# php55u-fpm

[root@test]$ rpm -q php55u
php55u-5.5.1-2.ius.el6.x86_64
[root@test]$ php -v
PHP 5.5.1 (cli) (built: Jul 31 2013 10:48:32) 
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2013 Zend Technologies
[root@test]$ php-fpm -v
[31-Jul-2013 10:51:12] NOTICE: PHP message: PHP Warning:  Module 'json' already loaded in Unknown on line 0
PHP 5.5.1 (fpm-fcgi) (built: Jul 31 2013 10:48:58)
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2013 Zend Technologies
[root@test]$ php-ls -v
PHP Warning:  Module 'json' already loaded in Unknown on line 0PHP 5.5.1 (litespeed) (built: Jul 31 2013 10:49:31)
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2013 Zend Technologies
[root@test]$ 
[root@test]$ 


# after adding it to the without_shared variable, the warning disappears
[root@test]$ rpm -q php55u
php55u-5.5.1-3.ius.el6.x86_64
[root@test]$ php -v
PHP 5.5.1 (cli) (built: Jul 31 2013 12:39:04) 
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2013 Zend Technologies
[root@test]$ php-fpm -v
PHP 5.5.1 (fpm-fcgi) (built: Jul 31 2013 12:39:30)
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2013 Zend Technologies
[root@test]$ php-ls -v
PHP 5.5.1 (litespeed) (built: Jul 31 2013 12:39:53)
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2013 Zend Technologies
[root@test]$ 
```
