### PR TITLE
fix require and provides lines, stop php-fpm on uninstall

### DIFF
--- a/SPECS/php55u.spec
+++ b/SPECS/php55u.spec
@@ -201,7 +201,7 @@ Summary: PHP FastCGI Process Manager
 # Zend is licensed under Zend
 # TSRM and fpm are licensed under BSD
 License: PHP and Zend and BSD
-Requires: %{real_name}-common = %{version}-%{release}
+Requires: %{name}-common = %{version}-%{release}
 Requires(pre): /usr/sbin/useradd
 Provides: %{name}-fpm = %{version}-%{release}
 Provides: %{real_name}-fpm = %{version}-%{release}


### PR DESCRIPTION
There's some mistakes in some of the 'Require' and 'Provide' lines where they incorrectly claim to provides packages they don't provide or require php-common instead of %{name}-common.

Also php-fpm isn't removed or stopped when it is uninstalled.
