### PR TITLE
Remove default opcache extension ini creation

### DIFF
--- a/SPECS/php55u.spec
+++ b/SPECS/php55u.spec
@@ -1532,7 +1532,7 @@ for mod in pgsql odbc ldap snmp xmlrpc imap \
 %endif
     mbstring gd dom xsl soap bcmath dba xmlreader xmlwriter \
     simplexml bz2 calendar ctype exif ftp gettext gmp iconv \
-    sockets tokenizer opcache \
+    sockets tokenizer \
     pdo pdo_pgsql pdo_odbc pdo_sqlite \
 %if %{with_zip}
     zip \


### PR DESCRIPTION
Opcache isn't a standard PHP extension, instead a Zend extension, needing zend_extension= syntax instead.

Additionally, this is happening already under 10-opcache.ini, but attempting to then load the extension as
a standard extension might introduce strange behaviour.
